### PR TITLE
fix: ensure compose mdw returns aggregate `Result`

### DIFF
--- a/compose.ts
+++ b/compose.ts
@@ -1,10 +1,15 @@
 import { call } from "./fx/mod.ts";
 import type { Next } from "./query/mod.ts";
-import type { Instruction, Operation } from "./deps.ts";
-import { Ok } from "./deps.ts";
+import { Err, Instruction, Operation, Result } from "./deps.ts";
+import { resultAll } from "./result.ts";
 
 // deno-lint-ignore no-explicit-any
-export type BaseCtx = Record<string, any>;
+export interface BaseCtx<T extends any[] = any[]> {
+  // deno-lint-ignore no-explicit-any
+  [key: string]: any;
+  result: Result<T>;
+}
+
 export type BaseMiddleware<Ctx extends BaseCtx = BaseCtx, T = unknown> = (
   ctx: Ctx,
   next: Next,
@@ -24,12 +29,15 @@ export function compose<Ctx extends BaseCtx = BaseCtx, T = unknown>(
   }
 
   return function* composeFn(context: Ctx, mdw?: BaseMiddleware<Ctx, T>) {
+    // deno-lint-ignore no-explicit-any
+    const results: Result<any>[] = [];
     // last called middleware #
     let index = -1;
 
-    function* dispatch(i: number): Generator<Instruction, T | undefined, void> {
+    function* dispatch(i: number): Generator<Instruction, void, void> {
       if (i <= index) {
-        throw new Error("next() called multiple times");
+        results.push(Err(new Error("next() called multiple times")));
+        return;
       }
       index = i;
       let fn: BaseMiddleware<Ctx, T> | undefined = middleware[i];
@@ -40,15 +48,15 @@ export function compose<Ctx extends BaseCtx = BaseCtx, T = unknown>(
         return;
       }
       const nxt = dispatch.bind(null, i + 1);
-      const result = yield* fn(context, nxt);
-      return result;
+      const result = yield* call(() => {
+        if (!fn) return;
+        // deno-lint-ignore no-explicit-any
+        return fn(context, nxt) as any;
+      });
+      results.push(result);
+      context.result = resultAll(results);
     }
 
-    const result = yield* call(() => dispatch(0));
-    if (result.ok) {
-      return Ok(context);
-    } else {
-      return result;
-    }
+    yield* dispatch(0);
   };
 }

--- a/deno.lock
+++ b/deno.lock
@@ -265,6 +265,8 @@
     "https://esm.sh/v128/@types/prop-types@15.7.5/index.d.ts": "6a386ff939f180ae8ef064699d8b7b6e62bc2731a62d7fbf5e02589383838dea",
     "https://esm.sh/v128/@types/react@18.2.14/global.d.ts": "549df62b64a71004aee17685b445a8289013daf96246ce4d9b087d13d7a27a61",
     "https://esm.sh/v128/@types/react@18.2.14/index.d.ts": "9aac3002309f46089b251d57e7b16c20bb0e8be711867bd308009fb33562b46c",
+    "https://esm.sh/v128/@types/react@18.2.15/global.d.ts": "549df62b64a71004aee17685b445a8289013daf96246ce4d9b087d13d7a27a61",
+    "https://esm.sh/v128/@types/react@18.2.15/index.d.ts": "f55ede57bc191e4c9c326fc86393abaa7b20ea3b34199e4c0b118a703a4481b6",
     "https://esm.sh/v128/@types/scheduler@0.16.3/tracing.d.ts": "f5a8b384f182b3851cec3596ccc96cb7464f8d3469f48c74bf2befb782a19de5",
     "https://esm.sh/v128/csstype@3.1.2/index.d.ts": "4c68749a564a6facdf675416d75789ee5a557afda8960e0803cf6711fa569288"
   },

--- a/query/pipe.ts
+++ b/query/pipe.ts
@@ -1,4 +1,3 @@
-import { call } from "../fx/mod.ts";
 import { compose } from "../compose.ts";
 import type { OpFn, Payload } from "../types.ts";
 import { parallel } from "../mod.ts";
@@ -20,6 +19,7 @@ import type {
   Supervisor,
 } from "./types.ts";
 import { API_ACTION_PREFIX } from "../action.ts";
+import { Ok } from "../deps.ts";
 
 export interface SagaApi<Ctx extends PipeCtx> {
   use: (fn: Middleware<Ctx>) => void;
@@ -149,9 +149,10 @@ export function createPipe<Ctx extends PipeCtx = PipeCtx<any>>(
       key,
       payload: options,
       actionFn,
+      result: Ok(undefined),
     } as unknown as Ctx;
     const fn = compose(middleware);
-    yield* call(() => fn(ctx));
+    yield* fn(ctx);
     return ctx;
   }
 
@@ -226,7 +227,8 @@ export function createPipe<Ctx extends PipeCtx = PipeCtx<any>>(
         return;
       }
 
-      yield* call(() => match(ctx, next));
+      const result = yield* match(ctx, next);
+      return result;
     }
 
     return router;

--- a/query/types.ts
+++ b/query/types.ts
@@ -1,4 +1,4 @@
-import type { Operation } from "../deps.ts";
+import type { Operation, Result } from "../deps.ts";
 import type { LoadingItemState, LoadingPayload, Payload } from "../types.ts";
 
 type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N;
@@ -12,6 +12,7 @@ export interface PipeCtx<P = any> extends Payload<P> {
     CreateAction<PipeCtx>,
     CreateActionWithPayload<PipeCtx<P>, P>
   >;
+  result: Result<unknown[]>;
 }
 
 export interface LoaderCtx<P = unknown> extends PipeCtx<P> {

--- a/result.ts
+++ b/result.ts
@@ -1,0 +1,14 @@
+import { Ok, Result } from "./deps.ts";
+
+export function resultAll<T>(results: Result<T>[]): Result<T[]> {
+  const agg: T[] = [];
+  for (let i = 0; i < results.length; i += 1) {
+    const result = results[i];
+    if (result.ok) {
+      agg.push(result.value);
+    } else {
+      return result;
+    }
+  }
+  return Ok(agg);
+}

--- a/store/types.ts
+++ b/store/types.ts
@@ -1,17 +1,19 @@
 import type { Operation, Patch, Result, Scope, Task } from "../deps.ts";
+import { BaseCtx } from "../mod.ts";
 import type { OpFn } from "../types.ts";
 
 export type StoreUpdater<S extends AnyState> = (s: S) => S | void;
 
 export type Listener = () => void;
 
-export interface UpdaterCtx<S extends AnyState> {
+export interface UpdaterCtx<S extends AnyState> extends BaseCtx {
   updater: StoreUpdater<S> | StoreUpdater<S>[];
   patches: Patch[];
 }
 
 export interface AnyAction {
   type: string;
+  // deno-lint-ignore no-explicit-any
   [key: string]: any;
 }
 
@@ -20,6 +22,7 @@ export interface ActionWPayload<P> {
   payload: P;
 }
 
+// deno-lint-ignore no-explicit-any
 export type AnyState = Record<string, any>;
 
 declare global {
@@ -32,9 +35,11 @@ export interface FxStore<S extends AnyState> {
   getScope: () => Scope;
   getState: () => S;
   subscribe: (fn: Listener) => () => void;
-  update: (u: StoreUpdater<S>) => Operation<Result<UpdaterCtx<S>>>;
+  update: (u: StoreUpdater<S>) => Operation<UpdaterCtx<S>>;
   run: <T>(op: OpFn<T>) => Task<Result<T>>;
+  // deno-lint-ignore no-explicit-any
   dispatch: (a: AnyAction) => any;
   replaceReducer: (r: (s: S, a: AnyAction) => S) => void;
+  // deno-lint-ignore no-explicit-any
   [Symbol.observable]: () => any;
 }


### PR DESCRIPTION
There was a regression compared to `saga-query` for `createPipe()` where we were swallowing errors in the mdw pipeline.  This is largely because we are experimenting with the idea of ensuring all operations inside `starfx` are safe-by-default and return a `Result` instead of `throw`.

This effort is a design decision to treat errors-as-data.

In order to support safe-by-default inside our `compose()` function, we need to aggregate the `Result` of every mdw call and then attach an aggregate `Result` onto the `ctx` provided to `compose()`.

So now we require at least one field to always exist on `ctx` which is `ctx.result` which returns `Result<any[]>`.

If an error exists inside the aggregate results, we return it unwrapped as an error.  If no error exists in the results then we return a single `Result` with a list of values unwrapped.

```ts
it(tests, "error inside endpoint mdw", async () => {
  let called = false;
  const query = createPipe();
  query.use(function* (ctx, next) {
    yield* next();
    if (!ctx.result.ok) {
      called = true;
    }
  });

  query.use(query.routes());

  const fetchUsers = query.create(
    `/users`,
    { supervisor: takeEvery },
    function* processUsers() {
      throw new Error("some error");
    },
  );

  const store = await configureStore({
    initialState: {
      ...createQueryState(),
      users: {},
    },
  });
  store.run(query.bootup);
  store.dispatch(fetchUsers());
  asserts.assertEquals(called, true);
});
```