### PR TITLE
refactor: require data and loaders slices

### DIFF
--- a/query/api.test.ts
+++ b/query/api.test.ts
@@ -29,7 +29,7 @@ const testStore = () => {
   const schema = createSchema({
     users: slice.table<User>({ empty: emptyUser }),
     loaders: slice.loader(),
-    data: slice.table({ empty: {} }),
+    cache: slice.table({ empty: {} }),
   });
   const store = configureStore(schema);
   return { schema, store };
@@ -298,7 +298,7 @@ it(tests, "createApi with hash key on a large post", async () => {
   });
 
   expect([8, 9].includes(expectedKey.split("|")[1].length)).toBeTruthy();
-  expect(s.data[expectedKey]).toEqual({
+  expect(s.cache[expectedKey]).toEqual({
     "1": { id: "1", name: "test", email: email, largetext: largetext },
   });
 });

--- a/query/fetch.test.ts
+++ b/query/fetch.test.ts
@@ -23,7 +23,7 @@ const delay = (n = 200) =>
 const testStore = () => {
   const schema = createSchema({
     loaders: slice.loader(),
-    data: slice.table({ empty: {} }),
+    cache: slice.table({ empty: {} }),
   });
   const store = configureStore(schema);
   return { schema, store };
@@ -68,7 +68,7 @@ it(
     await delay();
 
     const state = store.getState();
-    expect(state.data[action.payload.key]).toEqual(mockUser);
+    expect(state.cache[action.payload.key]).toEqual(mockUser);
 
     expect(actual).toEqual([{
       url: `${baseUrl}/users`,
@@ -151,7 +151,7 @@ it(tests, "error handling", async () => {
   await delay();
 
   const state = store.getState();
-  expect(state.data[action.payload.key]).toEqual(errMsg);
+  expect(state.cache[action.payload.key]).toEqual(errMsg);
   expect(actual).toEqual({ ok: false, data: errMsg, error: errMsg });
 });
 
@@ -191,7 +191,7 @@ it(tests, "status 204", async () => {
   await delay();
 
   const state = store.getState();
-  expect(state.data[action.payload.key]).toEqual({});
+  expect(state.cache[action.payload.key]).toEqual({});
   expect(actual).toEqual({ ok: true, data: {}, value: {} });
 });
 
@@ -429,7 +429,7 @@ it(
     await delay();
 
     const state = store.getState();
-    expect(state.data[action.payload.key]).toEqual(mockUser);
+    expect(state.cache[action.payload.key]).toEqual(mockUser);
     expect(actual).toEqual({ ok: true, data: mockUser, value: mockUser });
   },
 );

--- a/query/mdw.test.ts
+++ b/query/mdw.test.ts
@@ -34,7 +34,7 @@ const testStore = () => {
   const schema = createSchema({
     users: slice.table<User>({ empty: emptyUser }),
     loaders: slice.loader(),
-    data: slice.table({ empty: {} }),
+    cache: slice.table({ empty: {} }),
   });
   const store = configureStore(schema);
   return { schema, store };
@@ -410,7 +410,7 @@ it(tests, "createApi with own key", async () => {
     : createKey("/users [POST]", { email: newUEmail });
 
   const s = store.getState();
-  asserts.assertEquals(schema.db.data.selectById(s, { id: expectedKey }), {
+  asserts.assertEquals(schema.db.cache.selectById(s, { id: expectedKey }), {
     "1": { id: "1", name: "test", email: newUEmail },
   });
 
@@ -480,7 +480,7 @@ it(tests, "createApi with custom key but no payload", async () => {
     : createKey("/users [GET]", null);
 
   const s = store.getState();
-  asserts.assertEquals(schema.db.data.selectById(s, { id: expectedKey }), {
+  asserts.assertEquals(schema.db.cache.selectById(s, { id: expectedKey }), {
     "1": mockUser,
   });
 

--- a/store/query.ts
+++ b/store/query.ts
@@ -9,15 +9,15 @@ import { TableOutput } from "./slice/table.ts";
 export function storeMdw<
   Ctx extends ApiCtx = ApiCtx,
   M extends AnyState = AnyState,
->({ data, loaders, errorFn }: {
+>({ cache, loaders, errorFn }: {
   loaders: LoaderOutput<M, AnyState>;
-  data: TableOutput<any, AnyState>;
+  cache: TableOutput<any, AnyState>;
   errorFn?: (ctx: Ctx) => string;
 }) {
   return compose<Ctx>([
     dispatchActions,
     loadingMonitor(loaders, errorFn),
-    simpleCache(data),
+    simpleCache(cache),
   ]);
 }
 

--- a/store/schema.test.ts
+++ b/store/schema.test.ts
@@ -25,6 +25,7 @@ it(tests, "general types and functionality", async () => {
     counter: slice.num(),
     dev: slice.any<boolean>(false),
     currentUser: slice.obj<User>(emptyUser),
+    cache: slice.table({ empty: {} }),
     loaders: slice.loader(),
   });
   const db = schema.db;
@@ -36,6 +37,7 @@ it(tests, "general types and functionality", async () => {
     counter: 0,
     dev: false,
     currentUser: { id: "", name: "" },
+    cache: {},
     loaders: {},
   });
   const userMap = schema.db.users.selectTable(store.getState());
@@ -74,6 +76,8 @@ it(tests, "general types and functionality", async () => {
 it(tests, "can work with a nested object", async () => {
   const schema = createSchema({
     currentUser: slice.obj<UserWithRoles>({ id: "", name: "", roles: [] }),
+    cache: slice.table({ empty: {} }),
+    loaders: slice.loader(),
   });
   const db = schema.db;
   const store = configureStore(schema);

--- a/store/schema.ts
+++ b/store/schema.ts
@@ -1,8 +1,15 @@
+import { AnyState } from "../types.ts";
 import { updateStore } from "./fx.ts";
+import { LoaderOutput } from "./slice/loader.ts";
+import { TableOutput } from "./slice/table.ts";
 import { BaseSchema, FxStore, StoreUpdater } from "./types.ts";
 
 export function createSchema<
-  O extends { [key: string]: (name: string) => BaseSchema<unknown> },
+  O extends {
+    loaders: <M extends AnyState>(s: string) => LoaderOutput<M, AnyState>;
+    cache: (s: string) => TableOutput<any, AnyState>;
+    [key: string]: (name: string) => BaseSchema<unknown>;
+  },
   S extends { [key in keyof O]: ReturnType<O[key]>["initialState"] },
 >(
   slices: O,


### PR DESCRIPTION
The goal of this PR is to enforce a certain schema shape in order to support middleware and `starfx/query`.  If we can assume that `schema.db.loaders` and `schema.db.cache` exist then it really helps build better abstractions on top of `starfx/store`.