### PR TITLE
feat(query): thunk and api thunks can simply accept payload

### DIFF
--- a/query/thunk.ts
+++ b/query/thunk.ts
@@ -209,7 +209,12 @@ export function createThunks<Ctx extends ThunkCtx = ThunkCtx<any>>(
       const key = createKey(name, options);
       return action({ name, key, options });
     };
-    actionFn.run = onApi;
+    actionFn.run = (action?: unknown): Operation<Ctx> => {
+      if (action && Object.hasOwn(action, "type")) {
+        return onApi(action as ActionWithPayload<CreateActionPayload>);
+      }
+      return onApi(actionFn(action));
+    };
     actionFn.use = (fn: Middleware<Ctx>) => {
       const cur = middlewareMap[name];
       if (cur) {

--- a/query/types.ts
+++ b/query/types.ts
@@ -121,7 +121,7 @@ export type CreateActionFnWithPayload<P = any> = (
 
 export interface CreateActionWithPayload<Ctx extends ThunkCtx, P>
   extends CreateActionFnWithPayload<P> {
-  run: (a: ActionWithPayload<CreateActionPayload<P>>) => Operation<Ctx>;
+  run: (a: ActionWithPayload<CreateActionPayload<P>> | P) => Operation<Ctx>;
   use: (mdw: Middleware<Ctx>) => void;
 }
 


### PR DESCRIPTION
# before

```ts
const fetchUsers = api.get("/users");
const fetchUser = api.get<{ id: string }>("/users/:id");
fetchUsers.run(fetchUsers());
fetchUser.run(fetchUser({ id: "1" }))
```

# after


```ts
const fetchUsers = api.get("/users");
const fetchUser = api.get<{ id: string }>("/users/:id");
fetchUsers.run();
fetchUser.run({ id: "1" })
```