### PR TITLE
feat: embed schema.update inside updater functions

### DIFF
--- a/store/mod.ts
+++ b/store/mod.ts
@@ -7,5 +7,6 @@ export * from "./slice/mod.ts";
 export * from "./schema.ts";
 export * from "./batch.ts";
 export * from "./persist.ts";
+export * from "./util.ts";
 import * as storeMdw from "./query.ts";
 export { storeMdw };

--- a/store/slice/table.test.ts
+++ b/store/slice/table.test.ts
@@ -82,9 +82,11 @@ it(tests, "gets a row", async () => {
     initialState,
   });
   await store.run(function* () {
-    yield* updateStore(
-      slice.add({ [first.id]: first, [second.id]: second, [third.id]: third }),
-    );
+    yield* slice.add({
+      [first.id]: first,
+      [second.id]: second,
+      [third.id]: third,
+    }) as any;
   });
 
   const row = slice.selectById(store.getState(), { id: "2" });

--- a/store/util.ts
+++ b/store/util.ts
@@ -1,0 +1,17 @@
+import { Operation } from "../deps.ts";
+import { AnyState } from "../types.ts";
+import { updateStore } from "./fx.ts";
+
+export type UpdaterFn<S> = (s: S) => void;
+export interface UpdaterFnWithIterator<S> extends UpdaterFn<S> {
+  [Symbol.iterator]: Operation<void>;
+}
+
+export function createUpdater<S extends AnyState>(
+  updater: (s: S) => void,
+): UpdaterFnWithIterator<S> {
+  (updater as any)[Symbol.iterator] = function* wrapUpdater() {
+    yield* updateStore(updater);
+  };
+  return updater as UpdaterFnWithIterator<S>;
+}


### PR DESCRIPTION
## Old
```ts
yield* schema.update(schema.users.add());
```

## New
```ts
yield* schema.users.add();
```

## Considerations
If users want to create their own slices then they need to be aware of the `createUpdater()` function when building their store updater functions.