### PR TITLE
refactor: enhanced thunk registry system

### DIFF
--- a/action.ts
+++ b/action.ts
@@ -70,7 +70,7 @@ export function* take(pattern: ActionPattern): Operation<Action> {
 
 export function* takeEvery<T>(
   pattern: ActionPattern,
-  op: (action: Action) => Operation<T>,
+  op: (action: AnyAction) => Operation<T>,
 ) {
   const fd = useActions(pattern);
   for (const action of yield* each(fd)) {
@@ -81,7 +81,7 @@ export function* takeEvery<T>(
 
 export function* takeLatest<T>(
   pattern: ActionPattern,
-  op: (action: Action) => Operation<T>,
+  op: (action: AnyAction) => Operation<T>,
 ) {
   const fd = useActions(pattern);
   let lastTask;
@@ -97,7 +97,7 @@ export function* takeLatest<T>(
 
 export function* takeLeading<T>(
   pattern: ActionPattern,
-  op: (action: Action) => Operation<T>,
+  op: (action: AnyAction) => Operation<T>,
 ) {
   while (true) {
     const action = yield* take(pattern);

--- a/query/api.ts
+++ b/query/api.ts
@@ -65,7 +65,11 @@ export function createApi<Ctx extends ApiCtx = ApiCtx>(
 
   return {
     use: thunks.use,
-    bootup: thunks.bootup,
+    /**
+     * @deprecated use `register()` instead
+     */
+    bootup: thunks.register,
+    register: thunks.register,
     create: thunks.create,
     routes: thunks.routes,
     reset: thunks.reset,

--- a/test.ts
+++ b/test.ts
@@ -1,5 +1,7 @@
 export { assert } from "https://deno.land/std@0.187.0/testing/asserts.ts";
 export {
+  afterAll,
+  beforeAll,
   beforeEach,
   describe,
   it,

--- a/test/create-key.test.ts
+++ b/test/create-key.test.ts
@@ -1,8 +1,17 @@
-import { describe, expect, it } from "../test.ts";
+import { afterAll, beforeAll, describe, expect, it } from "../test.ts";
 import { type ActionWithPayload, createApi } from "../mod.ts";
 
 const getKeyOf = (action: ActionWithPayload<{ key: string }>): string =>
   action.payload.key;
+
+const err = console.error;
+beforeAll(() => {
+  console.error = () => {};
+});
+
+afterAll(() => {
+  console.error = err;
+});
 
 const tests = describe("create-key");
 
@@ -10,6 +19,7 @@ it(
   tests,
   "options object keys order for action key identity - 0: empty options",
   () => {
+    console.warn = () => {};
     const api = createApi();
     api.use(api.routes());
     // no param

--- a/test/thunk.test.ts
+++ b/test/thunk.test.ts
@@ -505,3 +505,33 @@ it(tests, "should only call thunk once", () => {
   store.dispatch(action2());
   asserts.assertEquals(acc, "a");
 });
+
+it(tests, "should be able to create thunk after `register()`", () => {
+  const api = createThunks<RoboCtx>();
+  api.use(api.routes());
+  const store = createStore({ initialState: {} });
+  store.run(api.register);
+
+  let acc = "";
+  const action = api.create("/users", function* () {
+    acc += "a";
+  });
+  store.dispatch(action());
+  asserts.assertEquals(acc, "a");
+});
+
+it(tests, "should warn when calling thunk before registered", () => {
+  const err = console.error;
+  let called = false;
+  console.error = () => {
+    called = true;
+  };
+  const api = createThunks<RoboCtx>();
+  api.use(api.routes());
+  const store = createStore({ initialState: {} });
+
+  const action = api.create("/users");
+  store.dispatch(action());
+  asserts.assertEquals(called, true);
+  console.error = err;
+});


### PR DESCRIPTION
The current registry system for thunks works like this:

- User calls `const thunks = createThunks()`
- User creates **all** thunks `const go = thunks.create("go")`
- User registers thunks `store.run(thunks.bootup)`

However, there's a caveat with this implementation: all thunks must be created before `store.run` is called.  Further, since thunks are created at the module-level, if the module that exports those thunks isn't loaded before `thunk.bootup` is called then those thunks are silently ignored.

This change will make it so it doesn't matter when a thunk is created, we will "lazy load" it.

We still require `store.run(thunks.bootup)` to be called -- because we need access to the store and won't have it when creating a thunk.

We are also sending an error whenever a thunk is dispatched without it being registered which should help ensure thunks get properly registered.

We also changed the name of `thunks.bootup` to `thunks.register` to make it more clear that this is a registry system.