### PR TITLE
feat: support multiple stores registering the same thunk

### DIFF
--- a/store/store.ts
+++ b/store/store.ts
@@ -1,4 +1,7 @@
+import { ActionContext, API_ACTION_PREFIX, emit } from "../action.ts";
+import { BaseMiddleware, compose } from "../compose.ts";
 import {
+  createContext,
   createScope,
   createSignal,
   enablePatches,
@@ -6,15 +9,14 @@ import {
   produceWithPatches,
   Scope,
 } from "../deps.ts";
-import { BaseMiddleware, compose } from "../compose.ts";
-import type { AnyAction, AnyState, Next } from "../types.ts";
-import type { FxStore, Listener, StoreUpdater, UpdaterCtx } from "./types.ts";
 import { StoreContext, StoreUpdateContext } from "./context.ts";
-import { ActionContext, emit } from "../action.ts";
-import { API_ACTION_PREFIX } from "../action.ts";
 import { createRun } from "./run.ts";
 
+import type { AnyAction, AnyState, Next } from "../types.ts";
+import type { FxStore, Listener, StoreUpdater, UpdaterCtx } from "./types.ts";
 const stubMsg = "This is merely a stub, not implemented";
+
+let id = 0;
 
 // https://github.com/reduxjs/redux/blob/4a6d2fb227ba119d3498a43fab8f53fe008be64c/src/createStore.ts#L344
 function observable() {
@@ -33,6 +35,8 @@ export interface CreateStore<S extends AnyState> {
   initialState: S;
   middleware?: BaseMiddleware<UpdaterCtx<S>>[];
 }
+
+export const IdContext = createContext("starfx:id", 0);
 
 export function createStore<S extends AnyState>({
   initialState,
@@ -53,6 +57,7 @@ export function createStore<S extends AnyState>({
 
   const signal = createSignal<AnyAction, void>();
   scope.set(ActionContext, signal);
+  scope.set(IdContext, id++);
 
   function getScope() {
     return scope;
@@ -60,6 +65,10 @@ export function createStore<S extends AnyState>({
 
   function getState() {
     return state;
+  }
+
+  function getStoreId() {
+    return scope.get(IdContext);
   }
 
   function subscribe(fn: Listener) {
@@ -164,6 +173,7 @@ export function createStore<S extends AnyState>({
   const store = {
     getScope,
     getState,
+    getStoreId,
     subscribe,
     update,
     reset,

--- a/test/thunk.test.ts
+++ b/test/thunk.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../mod.ts";
 import { createStore, updateStore } from "../store/mod.ts";
 import { assertLike, asserts, describe, it } from "../test.ts";
+
 import type { Next, ThunkCtx } from "../mod.ts";
 
 // deno-lint-ignore no-explicit-any
@@ -622,6 +623,31 @@ it(
       acc,
       "b",
       "Expected 'b' after first API call, but got: " + acc,
+    );
+  },
+);
+
+it(
+  tests,
+  "should allow multiple stores to register a thunk",
+  () => {
+    const api1 = createThunks<RoboCtx>();
+    api1.use(api1.routes());
+    const storeA = createStore({ initialState: {} });
+    const storeB = createStore({ initialState: {} });
+    storeA.run(api1.register);
+    storeB.run(api1.register);
+    let acc = "";
+    const action = api1.create("/users", function* () {
+      acc += "b";
+    });
+    storeA.dispatch(action());
+    storeB.dispatch(action());
+
+    asserts.assertEquals(
+      acc,
+      "bb",
+      "Expected 'bb' after first API call, but got: " + acc,
     );
   },
 );


### PR DESCRIPTION
This pull request introduces several changes to the `query/thunk.ts`, `store/store.ts`, and `test/thunk.test.ts` files to support multiple stores registering same thunk. The most important changes include adding a unique store ID context, modifying the thunk creation process to handle multiple store registrations, and adding tests to ensure the new functionality works as expected.

### Support for Multiple Store Registrations:

* Added `IdContext` to manage unique store IDs and updated `createStore` to set this context (`store/store.ts`). [[1]](diffhunk://#diff-23f7493f4d677af7b4e76ce2e5bcd2a23e2258f36000591d12bc9ef31d5c4602R1-R20) [[2]](diffhunk://#diff-23f7493f4d677af7b4e76ce2e5bcd2a23e2258f36000591d12bc9ef31d5c4602R39-R40) [[3]](diffhunk://#diff-23f7493f4d677af7b4e76ce2e5bcd2a23e2258f36000591d12bc9ef31d5c4602R60)
* Modified `createThunks` to use the `IdContext` for registering thunks with unique store IDs (`query/thunk.ts`). [[1]](diffhunk://#diff-efccbb3a45259561f802d454dd091c6bd4988b3c5b9d7f48d20e98f9eae5087aR129-R139) [[2]](diffhunk://#diff-efccbb3a45259561f802d454dd091c6bd4988b3c5b9d7f48d20e98f9eae5087aL210-R215) [[3]](diffhunk://#diff-efccbb3a45259561f802d454dd091c6bd4988b3c5b9d7f48d20e98f9eae5087aL256-R278)

### Code Enhancements:

* Introduced a unique `thunkId` incrementer to replace the previous random ID generation (`query/thunk.ts`). [[1]](diffhunk://#diff-efccbb3a45259561f802d454dd091c6bd4988b3c5b9d7f48d20e98f9eae5087aR85-R86) [[2]](diffhunk://#diff-efccbb3a45259561f802d454dd091c6bd4988b3c5b9d7f48d20e98f9eae5087aR129-R139)

### Testing:

*  Incorporated @neurosnap's proposed test case to verify that multiple stores can register and dispatch the same thunk (`test/thunk.test.ts`).