### PR TITLE
confirm tests assert when run within an generator function

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -37,9 +37,9 @@ export {
   useScope,
 } from "https://deno.land/x/effection@3.0.0-beta.3/mod.ts";
 
-import React from 'https://esm.sh/react@18.2.0?pin=v135';
+import React from "https://esm.sh/react@18.2.0?pin=v135";
 
-export type { JSX } from 'https://esm.sh/react@18.2.0?pin=v135';
+export type { JSX } from "https://esm.sh/react@18.2.0?pin=v135";
 
 export { React };
 export {

--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,61 @@
+export type {
+  Callable,
+  Channel,
+  Instruction,
+  Operation,
+  Predicate,
+  Queue,
+  Reject,
+  Resolve,
+  Result,
+  Scope,
+  Signal,
+  Stream,
+  Subscription,
+  Task,
+} from "https://deno.land/x/effection@3.0.0-beta.3/mod.ts";
+export {
+  action,
+  call,
+  createChannel,
+  createContext,
+  createQueue,
+  createScope,
+  createSignal,
+  each,
+  ensure,
+  Err,
+  Ok,
+  race,
+  resource,
+  run,
+  SignalQueueFactory,
+  sleep,
+  spawn,
+  suspend,
+  useAbortSignal,
+  useScope,
+} from "https://deno.land/x/effection@3.0.0-beta.3/mod.ts";
+
+import React from 'https://esm.sh/react@18.2.0?pin=v135';
+
+export type { JSX } from 'https://esm.sh/react@18.2.0?pin=v135';
+
+export { React };
+export {
+  Provider,
+  useDispatch,
+  useSelector,
+  useStore,
+} from "https://esm.sh/react-redux@8.0.5?pin=v135";
+export type {
+  TypedUseSelectorHook,
+} from "https://esm.sh/react-redux@8.0.5?pin=v135";
+export { createSelector } from "https://esm.sh/reselect@4.1.8?pin=v135";
+
+export {
+  enablePatches,
+  produce,
+  produceWithPatches,
+} from "https://esm.sh/immer@10.0.2?pin=v135";
+export type { Patch } from "https://esm.sh/immer@10.0.2?pin=v135";

--- a/test.ts
+++ b/test.ts
@@ -5,6 +5,7 @@ export {
   describe,
   it,
 } from "jsr:@std/testing/bdd";
+export * as assertType from "jsr:@std/testing/types";
 export { assert } from "jsr:@std/assert";
 export * as asserts from "jsr:@std/assert";
 export { expect } from "jsr:@std/expect";

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,12 +1,27 @@
 import {
-    AnyState, API_ACTION_PREFIX, ApiCtx, call, createApi, createKey, keepAlive, mdw, Operation,
-    safe, takeEvery, waitFor
-} from '../mod.ts';
-import { useCache } from '../react.ts';
+  AnyState,
+  API_ACTION_PREFIX,
+  ApiCtx,
+  call,
+  createApi,
+  createKey,
+  keepAlive,
+  mdw,
+  Operation,
+  safe,
+  takeEvery,
+  waitFor,
+} from "../mod.ts";
+import { useCache } from "../react.ts";
 import {
-    createSchema, createStore, select, slice, updateStore, waitForLoader
-} from '../store/mod.ts';
-import { describe, expect, it } from '../test.ts';
+  createSchema,
+  createStore,
+  select,
+  slice,
+  updateStore,
+  waitForLoader,
+} from "../store/mod.ts";
+import { describe, expect, it } from "../test.ts";
 
 interface User {
   id: string;

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -48,6 +48,7 @@ const jsonBlob = (data: unknown) => {
 const tests = describe("createApi()");
 
 it(tests, "POST", async () => {
+  expect.assertions(2);
   const query = createApi();
   query.use(mdw.queryCtx);
   query.use(mdw.nameParser);
@@ -118,6 +119,7 @@ it(tests, "POST", async () => {
 });
 
 it(tests, "POST with uri", () => {
+  expect.assertions(1);
   const query = createApi();
   query.use(mdw.queryCtx);
   query.use(mdw.nameParser);
@@ -165,6 +167,7 @@ it(tests, "POST with uri", () => {
 });
 
 it(tests, "middleware - with request fn", () => {
+  expect.assertions(2);
   const query = createApi();
   query.use(mdw.queryCtx);
   query.use(mdw.nameParser);
@@ -185,6 +188,7 @@ it(tests, "middleware - with request fn", () => {
 });
 
 it(tests, "run() on endpoint action - should run the effect", () => {
+  expect.assertions(1);
   const api = createApi<TestCtx>();
   api.use(api.routes());
   let acc = "";
@@ -213,6 +217,7 @@ it(tests, "run() on endpoint action - should run the effect", () => {
 });
 
 it(tests, "run() from a normal saga", () => {
+  expect.assertions(5);
   const api = createApi();
   api.use(api.routes());
   let acc = "";

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,27 +1,12 @@
 import {
-  AnyState,
-  API_ACTION_PREFIX,
-  ApiCtx,
-  call,
-  createApi,
-  createKey,
-  keepAlive,
-  mdw,
-  Operation,
-  safe,
-  takeEvery,
-  waitFor,
-} from "../mod.ts";
-import { useCache } from "../react.ts";
+    AnyState, API_ACTION_PREFIX, ApiCtx, call, createApi, createKey, keepAlive, mdw, Operation,
+    safe, takeEvery, waitFor
+} from '../mod.ts';
+import { useCache } from '../react.ts';
 import {
-  createSchema,
-  createStore,
-  select,
-  slice,
-  updateStore,
-  waitForLoader,
-} from "../store/mod.ts";
-import { describe, expect, it } from "../test.ts";
+    createSchema, createStore, select, slice, updateStore, waitForLoader
+} from '../store/mod.ts';
+import { describe, expect, it } from '../test.ts';
 
 interface User {
   id: string;
@@ -264,8 +249,8 @@ it(tests, "run() from a normal saga", async () => {
   const payload = { name: "/users/:id [GET]", options: { id: "1" } };
 
   expect(extractedResults.actionType).toEqual(`${API_ACTION_PREFIX}${action1}`);
-  expect(extractedResults.payload!["name"]).toEqual(payload.name);
-  expect(extractedResults.payload!["options"]).toEqual(payload.options);
+  expect(extractedResults.actionPayload!["name"]).toEqual(payload.name);
+  expect(extractedResults.actionPayload!["options"]).toEqual(payload.options);
   expect(extractedResults.name).toEqual("/users/:id [GET]");
   expect(extractedResults.payload).toEqual({ id: "1" });
   expect(acc).toEqual("ab");

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,14 +1,6 @@
-import { describe, expect, it } from "../test.ts";
-import {
-  createSchema,
-  createStore,
-  select,
-  slice,
-  updateStore,
-  waitForLoader,
-} from "../store/mod.ts";
 import {
   AnyState,
+  API_ACTION_PREFIX,
   ApiCtx,
   call,
   createApi,
@@ -21,6 +13,15 @@ import {
   waitFor,
 } from "../mod.ts";
 import { useCache } from "../react.ts";
+import {
+  createSchema,
+  createStore,
+  select,
+  slice,
+  updateStore,
+  waitForLoader,
+} from "../store/mod.ts";
+import { describe, expect, it } from "../test.ts";
 
 interface User {
   id: string;
@@ -216,8 +217,8 @@ it(tests, "run() on endpoint action - should run the effect", () => {
   store.dispatch(action2());
 });
 
-it(tests, "run() from a normal saga", () => {
-  expect.assertions(5);
+it(tests, "run() from a normal saga", async () => {
+  expect.assertions(6);
   const api = createApi();
   api.use(api.routes());
   let acc = "";
@@ -231,28 +232,43 @@ it(tests, "run() from a normal saga", () => {
       acc += "a";
     },
   );
+  const extractedResults = {
+    actionType: null,
+    actionPayload: null,
+    name: null,
+    payload: null,
+  };
   const action2 = () => ({ type: "ACTION" });
   function* onAction() {
     const ctx = yield* safe(() => action1.run(action1({ id: "1" })));
     if (!ctx.ok) {
       throw new Error("no ctx");
     }
-    const payload = { name: "/users/:id [GET]", options: { id: "1" } };
-    expect(ctx.value.action.type).toEqual(`@@starfx${action1}`);
-    expect(ctx.value.action.payload).toEqual(payload);
-    expect(ctx.value.name).toEqual("/users/:id [GET]");
-    expect(ctx.value.payload).toEqual({ id: "1" });
+    Object.assign(extractedResults, {
+      actionType: ctx.value.action.type,
+      actionPayload: ctx.value.action.payload,
+      name: ctx.value.name,
+      payload: ctx.value.payload,
+    });
     acc += "b";
-    expect(acc).toEqual("ab");
   }
-
   function* watchAction() {
-    yield* takeEvery(`${action2}`, onAction);
+    yield* takeEvery(action2, onAction);
   }
 
   const store = createStore({ initialState: { users: {} } });
   store.run(() => keepAlive([api.bootup, watchAction]));
   store.dispatch(action2());
+
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  const payload = { name: "/users/:id [GET]", options: { id: "1" } };
+
+  expect(extractedResults.actionType).toEqual(`${API_ACTION_PREFIX}${action1}`);
+  expect(extractedResults.payload!["name"]).toEqual(payload.name);
+  expect(extractedResults.payload!["options"]).toEqual(payload.options);
+  expect(extractedResults.name).toEqual("/users/:id [GET]");
+  expect(extractedResults.payload).toEqual({ id: "1" });
+  expect(acc).toEqual("ab");
 });
 
 it(tests, "with hash key on a large post", async () => {

--- a/test/safe.test.ts
+++ b/test/safe.test.ts
@@ -4,6 +4,7 @@ import { call, run } from "../mod.ts";
 const tests = describe("call()");
 
 it(tests, "should call the generator function", async () => {
+  expect.assertions(1);
   function* me() {
     return "valid";
   }
@@ -15,6 +16,7 @@ it(tests, "should call the generator function", async () => {
 });
 
 it(tests, "should return an Err()", async () => {
+  expect.assertions(1);
   const err = new Error("bang!");
   function* me() {
     throw err;
@@ -30,6 +32,7 @@ it(tests, "should return an Err()", async () => {
 });
 
 it(tests, "should call a promise", async () => {
+  expect.assertions(1);
   const me = () =>
     new Promise<string>((resolve) => {
       setTimeout(() => {

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it } from "../test.ts";
+import { createScope, Operation, parallel, put, Result, take } from "../mod.ts";
 import {
   createStore,
   StoreContext,
   StoreUpdateContext,
   updateStore,
 } from "../store/mod.ts";
-import { createScope, Operation, parallel, put, Result, take } from "../mod.ts";
+import { describe, expect, it } from "../test.ts";
 
 const tests = describe("store");
 
@@ -61,28 +61,24 @@ it(
       dev: false,
     };
     createStore({ scope, initialState });
-
+    let store;
     await scope.run(function* (): Operation<Result<void>[]> {
       const result = yield* parallel([
         function* () {
-          const store = yield* StoreContext;
+          store = yield* StoreContext;
           const chan = yield* StoreUpdateContext;
           const msgList = yield* chan.subscribe();
           yield* msgList.next();
-          expect(store.getState()).toEqual({
-            users: { 1: { id: "1", name: "eric" }, 3: { id: "", name: "" } },
-            theme: "",
-            token: null,
-            dev: true,
-          });
         },
-
         function* () {
           yield* updateStore(updateUser({ id: "1", name: "eric" }));
         },
       ]);
-
       return yield* result;
+    });
+    expect(store!.getState()).toEqual({
+      users: { 1: { id: "1", name: "eric" }, 3: { id: "", name: "" } },
+      dev: true,
     });
   },
 );

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1,4 +1,4 @@
-import { asserts, describe, it } from "../test.ts";
+import { describe, expect, it } from "../test.ts";
 import {
   createStore,
   StoreContext,
@@ -54,6 +54,7 @@ it(
   tests,
   "update store and receives update from channel `StoreUpdateContext`",
   async () => {
+    expect.assertions(1);
     const [scope] = createScope();
     const initialState: Partial<State> = {
       users: { 1: { id: "1", name: "testing" }, 2: { id: "2", name: "wow" } },
@@ -68,7 +69,7 @@ it(
           const chan = yield* StoreUpdateContext;
           const msgList = yield* chan.subscribe();
           yield* msgList.next();
-          asserts.assertEquals(store.getState(), {
+          expect(store.getState()).toEqual({
             users: { 1: { id: "1", name: "eric" }, 3: { id: "", name: "" } },
             theme: "",
             token: null,
@@ -87,6 +88,7 @@ it(
 );
 
 it(tests, "update store and receives update from `subscribe()`", async () => {
+  expect.assertions(1);
   const initialState: Partial<State> = {
     users: { 1: { id: "1", name: "testing" }, 2: { id: "2", name: "wow" } },
     dev: false,
@@ -96,7 +98,7 @@ it(tests, "update store and receives update from `subscribe()`", async () => {
   const store = createStore({ initialState });
 
   store.subscribe(() => {
-    asserts.assertEquals(store.getState(), {
+    expect(store.getState()).toEqual({
       users: { 1: { id: "1", name: "eric" }, 3: { id: "", name: "" } },
       dev: true,
       theme: "",
@@ -110,6 +112,7 @@ it(tests, "update store and receives update from `subscribe()`", async () => {
 });
 
 it(tests, "emit Action and update store", async () => {
+  expect.assertions(1);
   const initialState: Partial<State> = {
     users: { 1: { id: "1", name: "testing" }, 2: { id: "2", name: "wow" } },
     dev: false,
@@ -131,7 +134,7 @@ it(tests, "emit Action and update store", async () => {
     yield* result;
   });
 
-  asserts.assertEquals(store.getState(), {
+  expect(store.getState()).toEqual({
     users: { 1: { id: "1", name: "eric" }, 3: { id: "", name: "" } },
     theme: "",
     token: "",
@@ -140,6 +143,7 @@ it(tests, "emit Action and update store", async () => {
 });
 
 it(tests, "resets store", async () => {
+  expect.assertions(2);
   const initialState: Partial<State> = {
     users: { 1: { id: "1", name: "testing" }, 2: { id: "2", name: "wow" } },
     dev: false,
@@ -156,7 +160,7 @@ it(tests, "resets store", async () => {
     });
   });
 
-  asserts.assertEquals(store.getState(), {
+  expect(store.getState()).toEqual({
     users: { 3: { id: "3", name: "hehe" } },
     theme: "darkness",
     token: "",
@@ -165,7 +169,7 @@ it(tests, "resets store", async () => {
 
   await store.run(store.reset(["users"]));
 
-  asserts.assertEquals(store.getState(), {
+  expect(store.getState()).toEqual({
     users: { 3: { id: "3", name: "hehe" } },
     dev: false,
     theme: "",

--- a/test/thunk.test.ts
+++ b/test/thunk.test.ts
@@ -8,7 +8,7 @@ import {
   waitFor,
 } from "../mod.ts";
 import { createStore, updateStore } from "../store/mod.ts";
-import { assertLike, describe, expect, it } from "../test.ts";
+import { describe, expect, it } from "../test.ts";
 
 import type { Next, ThunkCtx } from "../mod.ts";
 // deno-lint-ignore no-explicit-any


### PR DESCRIPTION
## Motivation

We had a few tests that could include a race condition and not _actually_ run any assertions. Add a check to confirm the number of assertions for each test that has this type of pattern. Any test that executes functions and asserts on the return shouldn't require this check.
