### PR TITLE
preview package creation on PR

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,36 @@
+name: preview
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: setup deno
+        uses: denoland/setup-deno@v2
+      - name: get version
+        id: vars
+        run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^v//')
+      - name: setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 18.x
+          registry-url: https://registry.npmjs.com
+      - name: build
+        run: deno task npm $NPM_VERSION
+        env:
+          NPM_VERSION: ${{steps.vars.outputs.version}}
+
+      - name: checkout neurosnap/starfx-examples
+        uses: actions/checkout@v4
+        with:
+          repository: neurosnap/starfx-examples
+          path: examples
+
+      - name: Publish Preview Versions
+        run: npx pkg-pr-new publish './npm' --template './examples/*'


### PR DESCRIPTION
## Motivation

Preview packages will enable us to iterate and test more quickly. Depending on setup, getting a package from here (in Deno) into a downstream use case can be involved. With this, every PR commit will publish an updated version of the package to an `npm` compatible registry.
