### PR TITLE
Refactor matcher for correct predicate and action handling

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -8,6 +8,7 @@ import {
   createContext,
   createSignal,
   each,
+  sleep,
   spawn,
 } from "effection";
 import { type ActionPattern, matcher } from "./matcher.js";
@@ -64,7 +65,6 @@ export function* take(pattern: ActionPattern): Operation<Action> {
   for (const action of yield* each(fd)) {
     return action;
   }
-
   return { type: "take failed, this should not be possible" };
 }
 
@@ -141,6 +141,12 @@ export function createAction(actionType: string) {
     payload,
   });
   fn.toString = () => actionType;
-
+  //branding our creator //
+  Object.defineProperty(fn, "_starfx", {
+    value: true,
+    enumerable: false, // hide from Object.keys and spreads
+    configurable: false,
+    writable: false,
+  });
   return fn;
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -8,7 +8,6 @@ import {
   createContext,
   createSignal,
   each,
-  sleep,
   spawn,
 } from "effection";
 import { type ActionPattern, matcher } from "./matcher.js";
@@ -141,10 +140,9 @@ export function createAction(actionType: string) {
     payload,
   });
   fn.toString = () => actionType;
-  //branding our creator //
   Object.defineProperty(fn, "_starfx", {
     value: true,
-    enumerable: false, // hide from Object.keys and spreads
+    enumerable: false,
     configurable: false,
     writable: false,
   });

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -67,4 +67,3 @@ export function matcher(pattern: ActionPattern): Predicate {
 
   throw new Error("invalid pattern");
 }
-

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -1,4 +1,3 @@
-import { clearTimers } from "./supervisor.js";
 import type { AnyAction } from "./types.js";
 
 type ActionType = string;
@@ -30,7 +29,6 @@ function isThunk(fn: any): boolean {
     typeof fn.run === "function" &&
     typeof fn.use === "function" &&
     typeof fn.name === "string" &&
-    typeof fn.key === "string" &&
     typeof fn.toString === "function"
   );
 }
@@ -60,7 +58,6 @@ export function matcher(pattern: ActionPattern): Predicate {
     return (input) => pattern(input) as boolean;
   }
 
-  // starfx-branded action creator
   if (isActionCreator(pattern)) {
     return (input: AnyAction) => pattern.toString() === input.type;
   }

--- a/src/test/action.test.ts
+++ b/src/test/action.test.ts
@@ -10,3 +10,13 @@ test("return object with type", () => {
   const undo = createAction("UNDO");
   expect(undo()).toEqual({ type: "UNDO", payload: undefined });
 });
+
+test("createAction with object type should be compatible with UnknownAction", () => {
+  expect.assertions(1);
+  const emptyAction = createAction<object>("EMPTY_ACTION");
+  const action = emptyAction({});
+
+  // This should compile without TypeScript errors - testing the index signature
+  const hasIndexSignature = (action as any).someRandomProperty === undefined;
+  expect(hasIndexSignature).toBe(true);
+});

--- a/src/test/matcher.test.ts
+++ b/src/test/matcher.test.ts
@@ -1,5 +1,5 @@
 import {
-  ThunkCtx,
+  type ThunkCtx,
   createAction,
   createThunks,
   sleep,

--- a/src/test/matcher.test.ts
+++ b/src/test/matcher.test.ts
@@ -1,0 +1,182 @@
+import {
+  ThunkCtx,
+  createAction,
+  createThunks,
+  sleep,
+  spawn,
+  takeLatest,
+} from "../index.js";
+import { matcher } from "../matcher.js";
+import { createStore } from "../store/index.js";
+import { expect, test } from "../test.js";
+
+test("true", () => {
+  expect(true).toBe(true);
+});
+
+// The main thing
+test("createAction should not match all actions", async () => {
+  expect.assertions(1);
+
+  const store = createStore({ initialState: {} });
+  const matchedActions: string[] = [];
+
+  const testAction = createAction("test/action");
+
+  function* testFn(action: any) {
+    matchedActions.push(action.type);
+  }
+
+  function* root() {
+    yield* takeLatest(testAction, testFn);
+  }
+  const task = store.run(root);
+
+  store.dispatch({ type: "test/action", payload: { MenuOpened: "test" } });
+  store.dispatch({ type: "store", payload: { something: "else" } });
+  store.dispatch({ type: "other/action", payload: { data: "test" } });
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  expect(matchedActions).toEqual(["test/action"]);
+  await task.halt();
+});
+
+test("matcher should correctly identify createAction functions", () => {
+  expect.assertions(2);
+
+  const actionCreator = createAction("test/action");
+  const match = matcher(actionCreator);
+  expect(match({ type: "test/action", payload: {} })).toBe(true);
+  expect(match({ type: "other/action", payload: {} })).toBe(false);
+});
+
+test("typed createAction should work with takeLatest without type casting", async () => {
+  expect.assertions(1);
+
+  const store = createStore({ initialState: {} });
+  const matchedActions: string[] = [];
+
+  //typed action creator - this should work without 'as any'
+  const typedAction = createAction<{ MenuOpened: string }>("TYPED_ACTION");
+
+  function* handler(action: any) {
+    matchedActions.push(action.type);
+  }
+
+  function* root() {
+    // Should compile without TypeScript errors - no 'as any' needed
+    yield* takeLatest(typedAction, handler);
+  }
+
+  const task = store.run(root);
+
+  // dispatch the typed action
+  store.dispatch(typedAction({ MenuOpened: "settings" }));
+
+  // unrelated actions that should NOT trigger handler
+  store.dispatch({ type: "RANDOM_ACTION", payload: { data: "test" } });
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  expect(matchedActions).toEqual(["TYPED_ACTION"]);
+
+  await task.halt();
+});
+
+test("should correctly identify starfx thunk as a thunk", () => {
+  expect.assertions(3);
+
+  const thunks = createThunks();
+  thunks.use(thunks.routes());
+
+  const store = createStore({
+    initialState: {
+      users: {},
+    },
+  });
+  store.run(thunks.bootup);
+
+  const myThunk = thunks.create("my-thunk", function* (ctx, next) {
+    yield* next();
+  });
+
+  // Test that thunk has the expected properties for isThunk detection
+  expect(typeof myThunk.run).toBe("function");
+  expect(typeof myThunk.name).toBe("string");
+  expect(typeof myThunk.toString).toBe("function");
+});
+
+/// the bug that determined we needed to write this matcher
+test("some bug: createAction incorrectly matching all actions", async () => {
+  expect.assertions(1);
+
+  const store = createStore({ initialState: {} });
+  const matchedActions: string[] = [];
+
+  const testAction = createAction<{ MenuOpened: any }>("ACTION");
+
+  // Create a saga that should only respond to this specific action
+  function* testFn(action: any) {
+    matchedActions.push(action.type);
+    yield* sleep(1);
+  }
+
+  function* root() {
+    yield* takeLatest(testAction, testFn);
+  }
+
+  const task = store.run(root);
+
+  store.dispatch(testAction({ MenuOpened: "first" }));
+  store.dispatch({ type: "store", payload: { something: "else" } });
+  store.dispatch({ type: "other/action", payload: { data: "test" } });
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  expect(matchedActions).toEqual(["ACTION"]);
+
+  await task.halt();
+});
+
+test("should show the difference between createAction and thunk properties", () => {
+  expect.assertions(8);
+
+  // starfx createAction
+  const actionCreator = createAction<{ test: string }>("test/action");
+
+  // starfx thunk
+  const thunks = createThunks();
+  const myThunk = thunks.create("test-thunk", function* (ctx: ThunkCtx, next) {
+    yield* next();
+  });
+
+  // Check properties of createAction
+  expect(typeof actionCreator).toBe("function");
+  expect(typeof actionCreator.toString).toBe("function");
+  expect(actionCreator.toString()).toBe("test/action");
+  expect(typeof (actionCreator as any).run).toBe("undefined"); // createAction doesn't have run
+
+  // Check properties of thunk
+  expect(typeof myThunk).toBe("function");
+  expect(typeof myThunk.toString).toBe("function");
+  expect(typeof myThunk.run).toBe("function"); // thunk has run
+  expect(typeof myThunk.name).toBe("string"); // actionFn
+});
+
+test("debug: what path does createAction take in matcher", () => {
+  expect.assertions(6);
+
+  const actionCreator = createAction<{ test: string }>("test/action");
+
+  // Check what the isThunk function sees
+  const hasRun = typeof (actionCreator as any).run === "function";
+  const hasName = typeof actionCreator.name === "string";
+  const hasKey = typeof (actionCreator as any).key === "string";
+  const hasToString = typeof actionCreator.toString === "function";
+  const isFunction = typeof actionCreator === "function";
+  expect(hasRun).toBe(false);
+  expect(hasName).toBe(true); // function.name property
+  expect(hasKey).toBe(false);
+  expect(hasToString).toBe(true);
+  expect(isFunction).toBe(true);
+  expect(actionCreator.name).toBe("fn"); // function name, not thunk name
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export interface AnyAction extends Action {
   payload?: any;
   meta?: any;
   error?: boolean;
+  [extraProps: string]: any;
 }
 
 export interface ActionWithPayload<P> extends AnyAction {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export interface Payload<P = any> {
 
 export interface Action {
   type: string;
+  [extraProps: string]: any;
 }
 
 export type ActionFn = () => { toString: () => string };


### PR DESCRIPTION
**Motivation**

Previously, our matcher logic was too permissive and incorrectly matched any function—including user/test predicates—as an action creator.
This led to bugs where takeLatest (and similar effects) would react to unrelated actions, as shown by the failing test:

```ts
// matcher.test.ts
test("some bug: createAction incorrectly matching all actions", async () => {
  // ...
    function* root() {
    yield* takeLatest(testAction, testFn);
  }
 //...
  store.dispatch(testAction({ MenuOpened: "first" }));
  store.dispatch({ type: "store", payload: { something: "else" } });
  store.dispatch({ type: "other/action", payload: { data: "test" } });
  // ...
  expect(matchedActions).toEqual(["ACTION"]); // <--- was failing
});
```
The matcher was not reliably distinguishing between action creators and predicate functions, so unrelated actions could trigger effects unintentionally.

**Solution**

To address this, I implemented the following:

- Brand action creators using a cheap, non-enumerable `_starfx` property for precise detection.
- Refactor matcher logic to clearly separate branded action creators from custom predicates and all other cases.
- This ensures only the intended actions are matched, fixes the failing test, and makes the matcher safe for userland/test usage and advanced patterns.
- Additionally added `matcher.test.ts` to outline matcher behavior and edge cases, ensuring future changes remain safe.
- Also added index signature to `ActionWithPayload`  to ensure that is compatible with react-redux `UnknownAction` type [type.ts]

