### PR TITLE
react-redux as optional peerDep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
   "name": "starfx",
-  "version": "0.14.0",
+  "version": "0.14.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "starfx",
-      "version": "0.14.0",
+      "version": "0.14.4",
       "license": "MIT",
       "dependencies": {
         "effection": "^3.5.0",
         "immer": "^10.1.1",
-        "react-redux": "^9.2.0",
         "reselect": "^5.1.1"
       },
       "devDependencies": {
@@ -29,7 +28,13 @@
       },
       "peerDependencies": {
         "react": ">=18",
-        "react-dom": ">=18"
+        "react-dom": ">=18",
+        "react-redux": "9.x"
+      },
+      "peerDependenciesMeta": {
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@biomejs/biome": {
@@ -1029,7 +1034,9 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@vitest/expect": {
       "version": "3.2.0",
@@ -1716,6 +1723,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1739,6 +1747,8 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -2027,6 +2037,8 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
       "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "dependencies": {
     "effection": "^3.5.0",
     "immer": "^10.1.1",
-    "react-redux": "^9.2.0",
     "reselect": "^5.1.1"
   },
   "devDependencies": {
@@ -47,7 +46,19 @@
   },
   "peerDependencies": {
     "react": ">=18",
-    "react-dom": ">=18"
+    "react-dom": ">=18",
+    "react-redux": "9.x"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    },
+    "react-redux": {
+      "optional": true
+    }
   },
   "exports": {
     ".": {


### PR DESCRIPTION
## Motivation

The `react`, `react-dom`, and `react-redux` are only required if you use the `starfx/react`. That tends to be the original design of this lib, but use cases on the server have since evolved.

## Modifications

By marking these as `peerDeps` and `peerDepsMeta` `optional: true`, we short-circuit the normal `peerDep` handling. In both npm and pnpm, a `peerDep` will be automatically installed. With it marked optional, these deps will instead _not_ be installed by default. This does mean that the user will need to install all three if they are importing from `react-redux`.

This is helpful for cases such as within `@simulacrum/foundation-simulator` which had to list `react-dom` in the deps to account for the deps that come through `react-redux`.

## Alternatives

The only real alternative here is spinning off a new package to support the react hooks. In that case, we could add these as deps / peerDeps, but you would need to still install two packages.
