### PR TITLE
examples use repo starfx version

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -25,7 +25,13 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: npm install
+      - name: npm install in starfx root
+        run: npm install
+
+      - name: build starfx
+        run: npm run build
+
+      - name: npm install (uses built starfx)
         working-directory: ${{ matrix.example }}
         run: npm install
 

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -10,13 +10,13 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "starfx": "file:../.."
   },
   "devDependencies": {
-    "@types/react": "^18.0.28",
-    "@types/react-dom": "^18.0.11",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "@typescript-eslint/eslint-plugin": "^5.57.1",
     "@typescript-eslint/parser": "^5.57.1",
     "@vitejs/plugin-react": "^4.0.0",

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "starfx": "^0.13.0"
+    "starfx": "file:../.."
   },
   "devDependencies": {
     "@types/react": "^18.0.28",

--- a/examples/parcel-react/package.json
+++ b/examples/parcel-react/package.json
@@ -5,8 +5,12 @@
     "start": "parcel --host 0.0.0.0",
     "build": "parcel build"
   },
+  "browserslist": "> 0.5%, last 2 versions, not dead",
   "@parcel/resolver-default": {
     "packageExports": true
+  },
+  "alias": {
+    "node:process": false
   },
   "devDependencies": {
     "parcel": "^2.15.4",

--- a/examples/parcel-react/package.json
+++ b/examples/parcel-react/package.json
@@ -15,6 +15,6 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "starfx": "^0.13.0"
+    "starfx": "file:../.."
   }
 }

--- a/examples/parcel-react/package.json
+++ b/examples/parcel-react/package.json
@@ -13,8 +13,8 @@
     "process": "^0.11.10"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "starfx": "file:../.."
   }
 }

--- a/examples/parcel-react/package.json
+++ b/examples/parcel-react/package.json
@@ -9,7 +9,7 @@
     "packageExports": true
   },
   "devDependencies": {
-    "parcel": "^2.11.0",
+    "parcel": "^2.15.4",
     "process": "^0.11.10"
   },
   "dependencies": {

--- a/examples/tests-rtl/babel.config.js
+++ b/examples/tests-rtl/babel.config.js
@@ -2,5 +2,6 @@ module.exports = {
   presets: [
     "@babel/preset-env",
     ["@babel/preset-react", { runtime: "automatic" }],
+    "@babel/preset-typescript",
   ],
 };

--- a/examples/tests-rtl/jest.config.js
+++ b/examples/tests-rtl/jest.config.js
@@ -1,7 +1,11 @@
-module.exports = {
+export default {
   testEnvironment: "jsdom",
   transform: {
     "^.+\\.(t|j)sx?$": "babel-jest",
   },
   setupFilesAfterEnv: ["<rootDir>/tests/setup.ts"],
+  moduleNameMapper: {
+    "^react$": "<rootDir>/node_modules/react",
+    "^react-dom$": "<rootDir>/node_modules/react-dom",
+  },
 };

--- a/examples/tests-rtl/package.json
+++ b/examples/tests-rtl/package.json
@@ -4,8 +4,6 @@
     "test": "jest"
   },
   "dependencies": {
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
     "starfx": "file:../.."
   },
   "devDependencies": {
@@ -17,8 +15,6 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
-    "@types/react": "^19.1.8",
-    "@types/react-dom": "^19.1.6",
     "babel-jest": "^30.0.4",
     "jest": "^30.0.4",
     "jest-environment-jsdom": "^30.0.4",

--- a/examples/tests-rtl/package.json
+++ b/examples/tests-rtl/package.json
@@ -4,8 +4,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "starfx": "file:../.."
   },
   "devDependencies": {

--- a/examples/tests-rtl/package.json
+++ b/examples/tests-rtl/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "starfx": "^0.13.3"
+    "starfx": "file:../.."
   },
   "devDependencies": {
     "@babel/preset-env": "^7.23.9",

--- a/examples/tests-rtl/package.json
+++ b/examples/tests-rtl/package.json
@@ -9,14 +9,19 @@
     "starfx": "file:../.."
   },
   "devDependencies": {
-    "@babel/preset-env": "^7.23.9",
-    "@babel/preset-react": "^7.23.3",
-    "@testing-library/jest-dom": "^6.3.0",
-    "@testing-library/react": "^14.1.2",
-    "@testing-library/user-event": "^14.5.2",
-    "babel-jest": "^29.7.0",
-    "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0",
+    "@babel/core": "^7.28.0",
+    "@babel/preset-env": "^7.28.0",
+    "@babel/preset-react": "^7.27.1",
+    "@babel/preset-typescript": "^7.27.1",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "babel-jest": "^30.0.4",
+    "jest": "^30.0.4",
+    "jest-environment-jsdom": "^30.0.4",
     "whatwg-fetch": "^3.6.20"
   }
 }

--- a/examples/tests-rtl/tests/app.test.tsx
+++ b/examples/tests-rtl/tests/app.test.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+import "@testing-library/jest-dom";
 import { expect, test } from "@jest/globals";
 import { fireEvent, render, screen, waitFor } from "./utils";
 import { fetchUsers } from "../src/api";
@@ -20,7 +22,7 @@ test("fetches users", async () => {
           id: 2,
           name: "Ervin Howell",
         },
-      ]),
+      ])
     );
     yield* next();
   });

--- a/examples/tests-rtl/tests/utils.tsx
+++ b/examples/tests-rtl/tests/utils.tsx
@@ -1,10 +1,10 @@
-import React from "react";
-import { render } from "@testing-library/react";
+import React, { type ReactElement } from "react";
+import { render, type RenderOptions } from "@testing-library/react";
 import { Provider } from "starfx/react";
 import { schema } from "../src/api";
 import { setupStore } from "../src/store";
 
-const AllTheProviders = ({ children }) => {
+const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
   const store = setupStore({});
   return (
     <Provider schema={schema} store={store}>
@@ -13,8 +13,10 @@ const AllTheProviders = ({ children }) => {
   );
 };
 
-const customRender = (ui, options) =>
-  render(ui, { wrapper: AllTheProviders, ...options });
+const customRender = (
+  ui: ReactElement,
+  options?: Omit<RenderOptions, "wrapper">
+) => render(ui, { wrapper: AllTheProviders, ...options });
 
 // re-export everything
 export * from "@testing-library/react";

--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -10,16 +10,16 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "starfx": "file:../.."
   },
   "devDependencies": {
-    "@types/react": "^18.0.28",
-    "@types/react-dom": "^18.0.11",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "@typescript-eslint/eslint-plugin": "^5.57.1",
     "@typescript-eslint/parser": "^5.57.1",
-    "@vitejs/plugin-react": "^4.0.0",
+    "@vitejs/plugin-react": "^4.6.0",
     "eslint": "^8.38.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.3.4",

--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "starfx": "^0.13.0"
+    "starfx": "file:../.."
   },
   "devDependencies": {
     "@types/react": "^18.0.28",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "starfx",
-  "version": "0.14.0",
+  "version": "0.14.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "starfx",
-      "version": "0.14.0",
+      "version": "0.14.4",
       "license": "MIT",
       "dependencies": {
         "effection": "^3.5.0",


### PR DESCRIPTION
## Motivation

A little tweak so that each example will use the version of starfx in the repo when installed from the local. This should still work with the preview versions.
