### PR TITLE
destructure createScope

### DIFF
--- a/.changes/createScope-destructure.md
+++ b/.changes/createScope-destructure.md
@@ -1,0 +1,5 @@
+---
+"starfx": patch:deps
+---
+
+The `createScope` return signature change slightly in the upcoming version of `effection`. Adjusting preemptively for future compatibility.

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -86,13 +86,7 @@ export function createStore<S extends AnyState>({
   scope: initScope,
   middleware = [],
 }: CreateStore<S>): FxStore<S> {
-  let scope: Scope;
-  if (initScope) {
-    scope = initScope;
-  } else {
-    const tuple = createScope();
-    scope = tuple[0];
-  }
+  const [scope] = initScope ? [initScope] : createScope();
 
   let state = initialState;
   const listeners = new Set<Listener>();


### PR DESCRIPTION
## Motivation

The `createScope` return signature change slightly in the upcoming version of `effection`. Adjusting preemptively for future compatibility.

## Approach

Instead of presuming an array and taking the first arg, opt to destructure through the ternary. This will work with past, current and upcoming uses.
